### PR TITLE
fixed inconsistent wire hover effects and simultaneous wire and chip drag bug

### DIFF
--- a/includes/ChipArea.h
+++ b/includes/ChipArea.h
@@ -93,6 +93,7 @@ public:
     void updateClickedWires(CordDouble mousePos);
 
     bool shouldQueueDraw = false;
+    bool isClicked = false;
 
     void onMyLeftClick(int n_press, double x, double y);
     void onMyDeleteKeyPressed();

--- a/src/ChipArea.cc
+++ b/src/ChipArea.cc
@@ -524,7 +524,8 @@ void ChipArea::onMyLeftClick(int n_press, double x, double y)
                     bind->wire = wire;
                     globalOutputPins->at(i)->bindToGlobalOutput = bind;
                     clear_actions();
-                    break;
+                    run();
+                    return;
                 }
             }
 
@@ -549,7 +550,8 @@ void ChipArea::onMyLeftClick(int n_press, double x, double y)
                         bind->wire = wire;
                         chips->at(i)->inputPins[j]->bind = bind;
                         clear_actions();
-                        break;
+                        run();
+                        return;
                     }
                 }
             }

--- a/src/ChipArea.cc
+++ b/src/ChipArea.cc
@@ -253,18 +253,17 @@ ChipArea::ChipArea(ScreenStack *stack)
 
 bool ChipArea::isHoveringLine(CordDouble mousePos, CordDouble A, CordDouble B, double tolerance)
 {
+    int minDiff = 10;
     double dx = B.x - A.x;
     double dy = B.y - A.y;
-    if (dx == 0)
-    {
-        // Handle vertical line case (special handling)
-        return fabs(mousePos.x - A.x) <= tolerance;
-    }
+    bool isWithinXbounds = (mousePos.x > A.x && mousePos.x < B.x) || (mousePos.x > B.x && mousePos.x < A.x)||(abs(dx)<minDiff);
+    bool isWithinYbounds = (mousePos.y > A.y && mousePos.y < B.y) || (mousePos.y > B.y && mousePos.y < A.y)||(abs(dy)<minDiff);
+
+
+ 
 
     double distance = fabs(dy * mousePos.x - dx * mousePos.y + B.x * A.y - B.y * A.x) / sqrt(pow(dy, 2) + pow(dx, 2));
-
-    // check if withing the tolerance  and mouse within the segment , either A or B can be greater w.r.t X-axis
-    return distance <= tolerance && ((mousePos.x > A.x && mousePos.x < B.x) || (mousePos.x > B.x && mousePos.x < A.x));
+    return distance <= tolerance && isWithinXbounds &&isWithinYbounds;
 }
 
 bool ChipArea::isHoveringWire(CordDouble MousePos, Wire *wire, double tolerance)


### PR DESCRIPTION
# bug fix
This pull request adds modifications to the function ```bool ChipArea::isHoveringLine(CordDouble mousePos, CordDouble A, CordDouble B, double tolerance)``` such that inconsistent hovering is fixed. The changes have been tested to the best of my abilities.
